### PR TITLE
just build the test part

### DIFF
--- a/buildmaster/master.cfg
+++ b/buildmaster/master.cfg
@@ -837,7 +837,8 @@ def ZODB_dev_builder_git(name, slavename, platform, locks):
               name="bootstrap",
               description="bootstrap"))
     f.addStep(shell.ShellCommand(
-              command=platform.withcompiler % r"bin\buildout.exe",
+              command=[platform.withcompiler % r"bin\buildout.exe",
+                       'parts=test'],
               haltOnFailure=True,
               name="buildout",
               description="buildout",


### PR DESCRIPTION
The Zope buildout command should just build the test part.

I know nothing about buildbot.  It looks like the command argument can be a string or a list.  So I changed the buildout command to a list so I could add parts=test.
